### PR TITLE
Fix two deprecation warnings + project URL

### DIFF
--- a/gdsii/library.py
+++ b/gdsii/library.py
@@ -24,7 +24,7 @@ This module contains class that represents a GDSII library.
 """
 from __future__ import absolute_import
 from . import exceptions, record, structure, tags, _records
-from datetime import datetime
+from datetime import datetime, timezone
 
 _HEADER = _records.SimpleRecord('version', tags.HEADER)
 _BGNLIB = _records.TimestampsRecord('mod_time', 'acc_time', tags.BGNLIB)
@@ -77,8 +77,8 @@ class Library(list):
         self.name = name
         self.physical_unit = physical_unit
         self.logical_unit = logical_unit
-        self.mod_time = mod_time if mod_time is not None else datetime.utcnow()
-        self.acc_time = acc_time if acc_time is not None else datetime.utcnow()
+        self.mod_time = mod_time if mod_time is not None else datetime.now(timezone.utc)
+        self.acc_time = acc_time if acc_time is not None else datetime.now(timezone.utc)
         self._init_optional()
 
     def _init_optional(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description = long_desc,
     author = 'Eugeniy Meshcheryakov',
     author_email = 'eugen@debian.org',
-    url = 'http://www.gitorious.org/python-gdsii',
+    url = 'https://github.com/eugmes/python-gdsii',
     packages = ['gdsii'],
     scripts = [
         'scripts/gds2txt',


### PR DESCRIPTION
Thanks for this solid GDS library!

I have fixed two deprecation warnings:

- datetime.utcnow(): See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
- setup.py without pyproject.tml: See https://github.com/pypa/pip/issues/6334

Also, I have replaced the defunct Gitorious URL in setup.py (which is displayed on PyPI) with the URL of this GitHub repo.

If you are fine with the changes, maybe you can release the updated package as version 0.2.2?